### PR TITLE
better names for exported types

### DIFF
--- a/src/ffs/index.spec.ts
+++ b/src/ffs/index.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai"
 import fs from "fs"
 import { createFFS } from "."
-import { ffs } from "../types"
+import { ffsTypes } from "../types"
 import { getTransport, host, useToken } from "../util"
 import { withConfig, withHistory, withOverrideConfig } from "./options"
 
@@ -11,10 +11,10 @@ describe("ffs", () => {
   const c = createFFS({ host, transport: getTransport() }, getMeta)
 
   let instanceId: string
-  let initialAddrs: ffs.AddrInfo.AsObject[]
-  let defaultConfig: ffs.DefaultConfig.AsObject
+  let initialAddrs: ffsTypes.AddrInfo.AsObject[]
+  let defaultConfig: ffsTypes.DefaultConfig.AsObject
   let cid: string
-  let defaultCidConfig: ffs.CidConfig.AsObject
+  let defaultCidConfig: ffsTypes.CidConfig.AsObject
 
   it("should create an instance", async function () {
     this.timeout(30000)
@@ -92,9 +92,9 @@ describe("ffs", () => {
     this.timeout(180000)
     const cancel = c.watchJobs((job) => {
       expect(job.errCause).empty
-      expect(job.status).not.equal(ffs.JobStatus.JOB_STATUS_CANCELED)
-      expect(job.status).not.equal(ffs.JobStatus.JOB_STATUS_FAILED)
-      if (job.status === ffs.JobStatus.JOB_STATUS_SUCCESS) {
+      expect(job.status).not.equal(ffsTypes.JobStatus.JOB_STATUS_CANCELED)
+      expect(job.status).not.equal(ffsTypes.JobStatus.JOB_STATUS_FAILED)
+      if (job.status === ffsTypes.JobStatus.JOB_STATUS_SUCCESS) {
         cancel()
         done()
       }
@@ -145,9 +145,9 @@ describe("ffs", () => {
     this.timeout(180000)
     const cancel = c.watchJobs((job) => {
       expect(job.errCause).empty
-      expect(job.status).not.equal(ffs.JobStatus.JOB_STATUS_CANCELED)
-      expect(job.status).not.equal(ffs.JobStatus.JOB_STATUS_FAILED)
-      if (job.status === ffs.JobStatus.JOB_STATUS_SUCCESS) {
+      expect(job.status).not.equal(ffsTypes.JobStatus.JOB_STATUS_CANCELED)
+      expect(job.status).not.equal(ffsTypes.JobStatus.JOB_STATUS_FAILED)
+      if (job.status === ffsTypes.JobStatus.JOB_STATUS_SUCCESS) {
         cancel()
         done()
       }
@@ -172,7 +172,7 @@ describe("ffs", () => {
   })
 
   it("should push disable storage job", async () => {
-    const newConf: ffs.CidConfig.AsObject = {
+    const newConf: ffsTypes.CidConfig.AsObject = {
       cid,
       repairable: false,
       cold: {
@@ -192,9 +192,9 @@ describe("ffs", () => {
     this.timeout(180000)
     const cancel = c.watchJobs((job) => {
       expect(job.errCause).empty
-      expect(job.status).not.equal(ffs.JobStatus.JOB_STATUS_CANCELED)
-      expect(job.status).not.equal(ffs.JobStatus.JOB_STATUS_FAILED)
-      if (job.status === ffs.JobStatus.JOB_STATUS_SUCCESS) {
+      expect(job.status).not.equal(ffsTypes.JobStatus.JOB_STATUS_CANCELED)
+      expect(job.status).not.equal(ffsTypes.JobStatus.JOB_STATUS_FAILED)
+      if (job.status === ffsTypes.JobStatus.JOB_STATUS_SUCCESS) {
         cancel()
         done()
       }

--- a/src/ffs/index.ts
+++ b/src/ffs/index.ts
@@ -3,7 +3,7 @@ import {
   RPCService,
   RPCServiceClient,
 } from "@textile/grpc-powergate-client/dist/ffs/rpc/rpc_pb_service"
-import { Config, ffs } from "../types"
+import { Config, ffsTypes } from "../types"
 import { promise } from "../util"
 import { PushConfigOption, WatchLogsOption } from "./options"
 import { coldObjToMessage, hotObjToMessage } from "./util"
@@ -23,8 +23,8 @@ export const createFFS = (config: Config, getMeta: () => grpc.Metadata) => {
      */
     create: () =>
       promise(
-        (cb) => client.create(new ffs.CreateRequest(), cb),
-        (res: ffs.CreateResponse) => res.toObject(),
+        (cb) => client.create(new ffsTypes.CreateRequest(), cb),
+        (res: ffsTypes.CreateResponse) => res.toObject(),
       ),
 
     /**
@@ -33,8 +33,8 @@ export const createFFS = (config: Config, getMeta: () => grpc.Metadata) => {
      */
     list: () =>
       promise(
-        (cb) => client.listAPI(new ffs.ListAPIRequest(), cb),
-        (res: ffs.ListAPIResponse) => res.toObject(),
+        (cb) => client.listAPI(new ffsTypes.ListAPIRequest(), cb),
+        (res: ffsTypes.ListAPIResponse) => res.toObject(),
       ),
 
     /**
@@ -43,8 +43,8 @@ export const createFFS = (config: Config, getMeta: () => grpc.Metadata) => {
      */
     id: () =>
       promise(
-        (cb) => client.iD(new ffs.IDRequest(), getMeta(), cb),
-        (res: ffs.IDResponse) => res.toObject(),
+        (cb) => client.iD(new ffsTypes.IDRequest(), getMeta(), cb),
+        (res: ffsTypes.IDResponse) => res.toObject(),
       ),
 
     /**
@@ -53,8 +53,8 @@ export const createFFS = (config: Config, getMeta: () => grpc.Metadata) => {
      */
     addrs: () =>
       promise(
-        (cb) => client.addrs(new ffs.AddrsRequest(), getMeta(), cb),
-        (res: ffs.AddrsResponse) => res.toObject(),
+        (cb) => client.addrs(new ffsTypes.AddrsRequest(), getMeta(), cb),
+        (res: ffsTypes.AddrsResponse) => res.toObject(),
       ),
 
     /**
@@ -63,8 +63,8 @@ export const createFFS = (config: Config, getMeta: () => grpc.Metadata) => {
      */
     defaultConfig: () =>
       promise(
-        (cb) => client.defaultConfig(new ffs.DefaultConfigRequest(), getMeta(), cb),
-        (res: ffs.DefaultConfigResponse) => res.toObject(),
+        (cb) => client.defaultConfig(new ffsTypes.DefaultConfigRequest(), getMeta(), cb),
+        (res: ffsTypes.DefaultConfigResponse) => res.toObject(),
       ),
 
     /**
@@ -75,13 +75,13 @@ export const createFFS = (config: Config, getMeta: () => grpc.Metadata) => {
      * @returns Information about the newly created address
      */
     newAddr: (name: string, type?: "bls" | "secp256k1", makeDefault?: boolean) => {
-      const req = new ffs.NewAddrRequest()
+      const req = new ffsTypes.NewAddrRequest()
       req.setName(name)
       req.setAddressType(type || "bls")
       req.setMakeDefault(makeDefault || false)
       return promise(
         (cb) => client.newAddr(req, getMeta(), cb),
-        (res: ffs.NewAddrResponse) => res.toObject(),
+        (res: ffsTypes.NewAddrResponse) => res.toObject(),
       )
     },
 
@@ -91,11 +91,11 @@ export const createFFS = (config: Config, getMeta: () => grpc.Metadata) => {
      * @returns The storage config prepped for the provided cid
      */
     getDefaultCidConfig: (cid: string) => {
-      const req = new ffs.GetDefaultCidConfigRequest()
+      const req = new ffsTypes.GetDefaultCidConfigRequest()
       req.setCid(cid)
       return promise(
         (cb) => client.getDefaultCidConfig(req, getMeta(), cb),
-        (res: ffs.GetDefaultCidConfigResponse) => res.toObject(),
+        (res: ffsTypes.GetDefaultCidConfigResponse) => res.toObject(),
       )
     },
 
@@ -105,11 +105,11 @@ export const createFFS = (config: Config, getMeta: () => grpc.Metadata) => {
      * @returns The storage config for the provided cid
      */
     getCidConfig: (cid: string) => {
-      const req = new ffs.GetCidConfigRequest()
+      const req = new ffsTypes.GetCidConfigRequest()
       req.setCid(cid)
       return promise(
         (cb) => client.getCidConfig(req, getMeta(), cb),
-        (res: ffs.GetCidConfigResponse) => res.toObject(),
+        (res: ffsTypes.GetCidConfigResponse) => res.toObject(),
       )
     },
 
@@ -117,8 +117,8 @@ export const createFFS = (config: Config, getMeta: () => grpc.Metadata) => {
      * Set the default storage config for this FFS instance
      * @param config The new default storage config
      */
-    setDefaultConfig: (config: ffs.DefaultConfig.AsObject) => {
-      const c = new ffs.DefaultConfig()
+    setDefaultConfig: (config: ffsTypes.DefaultConfig.AsObject) => {
+      const c = new ffsTypes.DefaultConfig()
       c.setRepairable(config.repairable)
       if (config.hot) {
         c.setHot(hotObjToMessage(config.hot))
@@ -126,7 +126,7 @@ export const createFFS = (config: Config, getMeta: () => grpc.Metadata) => {
       if (config.cold) {
         c.setCold(coldObjToMessage(config.cold))
       }
-      const req = new ffs.SetDefaultConfigRequest()
+      const req = new ffsTypes.SetDefaultConfigRequest()
       req.setConfig(c)
       return promise(
         (cb) => client.setDefaultConfig(req, getMeta(), cb),
@@ -142,11 +142,11 @@ export const createFFS = (config: Config, getMeta: () => grpc.Metadata) => {
      * @returns The current storage config for the provided cid
      */
     show: (cid: string) => {
-      const req = new ffs.ShowRequest()
+      const req = new ffsTypes.ShowRequest()
       req.setCid(cid)
       return promise(
         (cb) => client.show(req, getMeta(), cb),
-        (res: ffs.ShowResponse) => res.toObject(),
+        (res: ffsTypes.ShowResponse) => res.toObject(),
       )
     },
 
@@ -156,8 +156,8 @@ export const createFFS = (config: Config, getMeta: () => grpc.Metadata) => {
      */
     info: () =>
       promise(
-        (cb) => client.info(new ffs.InfoRequest(), getMeta(), cb),
-        (res: ffs.InfoResponse) => res.toObject(),
+        (cb) => client.info(new ffsTypes.InfoRequest(), getMeta(), cb),
+        (res: ffsTypes.InfoResponse) => res.toObject(),
       ),
 
     /**
@@ -166,8 +166,8 @@ export const createFFS = (config: Config, getMeta: () => grpc.Metadata) => {
      * @param jobs A list of job ids to watch
      * @returns A function that can be used to cancel watching
      */
-    watchJobs: (handler: (event: ffs.Job.AsObject) => void, ...jobs: string[]) => {
-      const req = new ffs.WatchJobsRequest()
+    watchJobs: (handler: (event: ffsTypes.Job.AsObject) => void, ...jobs: string[]) => {
+      const req = new ffsTypes.WatchJobsRequest()
       req.setJidsList(jobs)
       const stream = client.watchJobs(req, getMeta())
       stream.on("data", (res) => {
@@ -187,11 +187,11 @@ export const createFFS = (config: Config, getMeta: () => grpc.Metadata) => {
      * @returns A function that can be used to cancel watching
      */
     watchLogs: (
-      handler: (event: ffs.LogEntry.AsObject) => void,
+      handler: (event: ffsTypes.LogEntry.AsObject) => void,
       cid: string,
       ...opts: WatchLogsOption[]
     ) => {
-      const req = new ffs.WatchLogsRequest()
+      const req = new ffsTypes.WatchLogsRequest()
       req.setCid(cid)
       opts.forEach((opt) => opt(req))
       const stream = client.watchLogs(req, getMeta())
@@ -211,12 +211,12 @@ export const createFFS = (config: Config, getMeta: () => grpc.Metadata) => {
      * @returns The job id of the job executing the storage configuration
      */
     replace: (cid1: string, cid2: string) => {
-      const req = new ffs.ReplaceRequest()
+      const req = new ffsTypes.ReplaceRequest()
       req.setCid1(cid1)
       req.setCid2(cid2)
       return promise(
         (cb) => client.replace(req, getMeta(), cb),
-        (res: ffs.ReplaceResponse) => res.toObject(),
+        (res: ffsTypes.ReplaceResponse) => res.toObject(),
       )
     },
 
@@ -227,14 +227,14 @@ export const createFFS = (config: Config, getMeta: () => grpc.Metadata) => {
      * @returns The job id of the job executing the storage configuration
      */
     pushConfig: (cid: string, ...opts: PushConfigOption[]) => {
-      const req = new ffs.PushConfigRequest()
+      const req = new ffsTypes.PushConfigRequest()
       req.setCid(cid)
       opts.forEach((opt) => {
         opt(req)
       })
       return promise(
         (cb) => client.pushConfig(req, getMeta(), cb),
-        (res: ffs.PushConfigResponse) => res.toObject(),
+        (res: ffsTypes.PushConfigResponse) => res.toObject(),
       )
     },
 
@@ -243,7 +243,7 @@ export const createFFS = (config: Config, getMeta: () => grpc.Metadata) => {
      * @param cid The cid to remove
      */
     remove: (cid: string) => {
-      const req = new ffs.RemoveRequest()
+      const req = new ffsTypes.RemoveRequest()
       req.setCid(cid)
       return promise(
         (cb) => client.remove(req, getMeta(), cb),
@@ -267,7 +267,7 @@ export const createFFS = (config: Config, getMeta: () => grpc.Metadata) => {
           return tmp
         }
         let final = new Uint8Array()
-        const req = new ffs.GetRequest()
+        const req = new ffsTypes.GetRequest()
         req.setCid(cid)
         const stream = client.get(req, getMeta())
         stream.on("data", (resp) => {
@@ -290,7 +290,7 @@ export const createFFS = (config: Config, getMeta: () => grpc.Metadata) => {
      * @param amount The amount of FIL to send
      */
     sendFil: (from: string, to: string, amount: number) => {
-      const req = new ffs.SendFilRequest()
+      const req = new ffsTypes.SendFilRequest()
       req.setFrom(from)
       req.setTo(to)
       req.setAmount(amount)
@@ -307,24 +307,24 @@ export const createFFS = (config: Config, getMeta: () => grpc.Metadata) => {
      */
     close: () =>
       promise(
-        (cb) => client.close(new ffs.CloseRequest(), getMeta(), cb),
+        (cb) => client.close(new ffsTypes.CloseRequest(), getMeta(), cb),
         () => {
           // nothing to return
         },
       ),
 
     /**
-     * A helper method to cache data in IPFS in preparation for storing in FFS.
+     * A helper method to cache data in IPFS in preparation for storing in ffsTypes.
      * This doesn't actually store data in FFS, you'll want to call pushConfig for that.
      * @param input The raw data to add
      * @returns The cid of the added data
      */
     addToHot: (input: Uint8Array) => {
       // TODO: figure out how to stream data in here, or at least stream to the server
-      return new Promise<ffs.AddToHotResponse.AsObject>((resolve, reject) => {
+      return new Promise<ffsTypes.AddToHotResponse.AsObject>((resolve, reject) => {
         const client = grpc.client(RPCService.AddToHot, config)
         client.onMessage((message) => {
-          resolve(message.toObject() as ffs.AddToHotResponse.AsObject)
+          resolve(message.toObject() as ffsTypes.AddToHotResponse.AsObject)
         })
         client.onEnd((code, msg) => {
           if (code !== grpc.Code.OK) {
@@ -334,7 +334,7 @@ export const createFFS = (config: Config, getMeta: () => grpc.Metadata) => {
           }
         })
         client.start(getMeta())
-        const req = new ffs.AddToHotRequest()
+        const req = new ffsTypes.AddToHotRequest()
         req.setChunk(input)
         client.send(req)
         client.finishSend()
@@ -347,8 +347,8 @@ export const createFFS = (config: Config, getMeta: () => grpc.Metadata) => {
      */
     listPayChannels: () =>
       promise(
-        (cb) => client.listPayChannels(new ffs.ListPayChannelsRequest(), getMeta(), cb),
-        (res: ffs.ListPayChannelsResponse) => res.toObject().payChannelsList,
+        (cb) => client.listPayChannels(new ffsTypes.ListPayChannelsRequest(), getMeta(), cb),
+        (res: ffsTypes.ListPayChannelsResponse) => res.toObject().payChannelsList,
       ),
 
     /**
@@ -359,13 +359,13 @@ export const createFFS = (config: Config, getMeta: () => grpc.Metadata) => {
      * @returns Information about the payment channel
      */
     createPayChannel: (from: string, to: string, amt: number) => {
-      const req = new ffs.CreatePayChannelRequest()
+      const req = new ffsTypes.CreatePayChannelRequest()
       req.setFrom(from)
       req.setTo(to)
       req.setAmount(amt)
       return promise(
         (cb) => client.createPayChannel(req, getMeta(), cb),
-        (res: ffs.CreatePayChannelResponse) => res.toObject(),
+        (res: ffsTypes.CreatePayChannelResponse) => res.toObject(),
       )
     },
 
@@ -374,7 +374,7 @@ export const createFFS = (config: Config, getMeta: () => grpc.Metadata) => {
      * @param payChannelAddr The address of the payment channel to redeem
      */
     redeemPayChannel: (payChannelAddr: string) => {
-      const req = new ffs.RedeemPayChannelRequest()
+      const req = new ffsTypes.RedeemPayChannelRequest()
       req.setPayChannelAddr(payChannelAddr)
       return promise(
         (cb) => client.redeemPayChannel(req, getMeta(), cb),
@@ -390,8 +390,8 @@ export const createFFS = (config: Config, getMeta: () => grpc.Metadata) => {
      */
     showAll: () =>
       promise(
-        (cb) => client.showAll(new ffs.ShowAllRequest(), getMeta(), cb),
-        (res: ffs.ShowAllResponse) => res.toObject().cidInfosList,
+        (cb) => client.showAll(new ffsTypes.ShowAllRequest(), getMeta(), cb),
+        (res: ffsTypes.ShowAllResponse) => res.toObject().cidInfosList,
       ),
   }
 }

--- a/src/ffs/options.ts
+++ b/src/ffs/options.ts
@@ -1,7 +1,7 @@
-import { ffs } from "../types"
+import { ffsTypes } from "../types"
 import { coldObjToMessage, hotObjToMessage } from "./util"
 
-export type PushConfigOption = (req: ffs.PushConfigRequest) => void
+export type PushConfigOption = (req: ffsTypes.PushConfigRequest) => void
 
 /**
  * Allows you to override an existing storage configuration
@@ -9,7 +9,7 @@ export type PushConfigOption = (req: ffs.PushConfigRequest) => void
  * @returns The resulting option
  */
 export const withOverrideConfig = (override: boolean) => {
-  const option: PushConfigOption = (req: ffs.PushConfigRequest) => {
+  const option: PushConfigOption = (req: ffsTypes.PushConfigRequest) => {
     req.setHasOverrideConfig(true)
     req.setOverrideConfig(override)
   }
@@ -21,9 +21,9 @@ export const withOverrideConfig = (override: boolean) => {
  * @param config The storage configuration to use
  * @returns The resulting option
  */
-export const withConfig = (config: ffs.CidConfig.AsObject) => {
-  const option: PushConfigOption = (req: ffs.PushConfigRequest) => {
-    const c = new ffs.CidConfig()
+export const withConfig = (config: ffsTypes.CidConfig.AsObject) => {
+  const option: PushConfigOption = (req: ffsTypes.PushConfigRequest) => {
+    const c = new ffsTypes.CidConfig()
     c.setCid(config.cid)
     c.setRepairable(config.repairable)
     if (config.hot) {
@@ -38,7 +38,7 @@ export const withConfig = (config: ffs.CidConfig.AsObject) => {
   return option
 }
 
-export type WatchLogsOption = (res: ffs.WatchLogsRequest) => void
+export type WatchLogsOption = (res: ffsTypes.WatchLogsRequest) => void
 
 /**
  * Control whether or not to include the history of log events
@@ -46,7 +46,7 @@ export type WatchLogsOption = (res: ffs.WatchLogsRequest) => void
  * @returns The resulting option
  */
 export const withHistory = (includeHistory: boolean) => {
-  const option: WatchLogsOption = (req: ffs.WatchLogsRequest) => {
+  const option: WatchLogsOption = (req: ffsTypes.WatchLogsRequest) => {
     req.setHistory(includeHistory)
   }
   return option
@@ -58,7 +58,7 @@ export const withHistory = (includeHistory: boolean) => {
  * @returns The resulting option
  */
 export const withJobId = (jobId: string) => {
-  const option: WatchLogsOption = (req: ffs.WatchLogsRequest) => {
+  const option: WatchLogsOption = (req: ffsTypes.WatchLogsRequest) => {
     req.setJid(jobId)
   }
   return option

--- a/src/ffs/util.ts
+++ b/src/ffs/util.ts
@@ -1,10 +1,10 @@
-import { ffs } from "../types"
+import { ffsTypes } from "../types"
 
-export function coldObjToMessage(obj: ffs.ColdConfig.AsObject) {
-  const cold = new ffs.ColdConfig()
+export function coldObjToMessage(obj: ffsTypes.ColdConfig.AsObject) {
+  const cold = new ffsTypes.ColdConfig()
   cold.setEnabled(obj.enabled)
   if (obj.filecoin) {
-    const fc = new ffs.FilConfig()
+    const fc = new ffsTypes.FilConfig()
     fc.setAddr(obj.filecoin.addr)
     fc.setCountryCodesList(obj.filecoin.countryCodesList)
     fc.setDealMinDuration(obj.filecoin.dealMinDuration)
@@ -13,7 +13,7 @@ export function coldObjToMessage(obj: ffs.ColdConfig.AsObject) {
     fc.setRepFactor(obj.filecoin.repFactor)
     fc.setTrustedMinersList(obj.filecoin.trustedMinersList)
     if (obj.filecoin.renew) {
-      const renew = new ffs.FilRenew()
+      const renew = new ffsTypes.FilRenew()
       renew.setEnabled(obj.filecoin.renew.enabled)
       renew.setThreshold(obj.filecoin.renew.threshold)
       fc.setRenew(renew)
@@ -23,12 +23,12 @@ export function coldObjToMessage(obj: ffs.ColdConfig.AsObject) {
   return cold
 }
 
-export function hotObjToMessage(obj: ffs.HotConfig.AsObject) {
-  const hot = new ffs.HotConfig()
+export function hotObjToMessage(obj: ffsTypes.HotConfig.AsObject) {
+  const hot = new ffsTypes.HotConfig()
   hot.setAllowUnfreeze(obj.allowUnfreeze)
   hot.setEnabled(obj.enabled)
   if (obj?.ipfs) {
-    const ipfs = new ffs.IpfsConfig()
+    const ipfs = new ffsTypes.IpfsConfig()
     ipfs.setAddTimeout(obj.ipfs.addTimeout)
     hot.setIpfs(ipfs)
   }

--- a/src/health/index.spec.ts
+++ b/src/health/index.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai"
 import { createHealth } from "."
-import { health } from "../types"
+import { healthTypes } from "../types"
 import { getTransport, host } from "../util"
 
 describe("health", () => {
@@ -8,6 +8,6 @@ describe("health", () => {
 
   it("should check health", async () => {
     const status = await c.check()
-    expect(status.status).equal(health.Status.STATUS_OK)
+    expect(status.status).equal(healthTypes.Status.STATUS_OK)
   })
 })

--- a/src/health/index.ts
+++ b/src/health/index.ts
@@ -1,5 +1,5 @@
 import { RPCServiceClient } from "@textile/grpc-powergate-client/dist/health/rpc/rpc_pb_service"
-import { Config, health } from "../types"
+import { Config, healthTypes } from "../types"
 import { promise } from "../util"
 
 /**
@@ -16,8 +16,8 @@ export const createHealth = (config: Config) => {
      */
     check: () =>
       promise(
-        (cb) => client.check(new health.CheckRequest(), cb),
-        (resp: health.CheckResponse) => resp.toObject(),
+        (cb) => client.check(new healthTypes.CheckRequest(), cb),
+        (resp: healthTypes.CheckResponse) => resp.toObject(),
       ),
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,10 @@ import { createHealth } from "./health"
 import { createMiners } from "./miners"
 import { createNet } from "./net"
 import { ffsOptions } from "./options"
-import { Config, ffs, health, miners, net } from "./types"
+import { Config, ffsTypes, healthTypes, minersTypes, netTypes } from "./types"
 import { getTransport, host, useToken } from "./util"
 
-export { Config, ffs, health, miners, net, ffsOptions }
+export { Config, ffsTypes, healthTypes, minersTypes, netTypes, ffsOptions }
 
 const defaultConfig: Config = {
   host,

--- a/src/miners/index.ts
+++ b/src/miners/index.ts
@@ -1,5 +1,5 @@
 import { RPCServiceClient } from "@textile/grpc-powergate-client/dist/index/miner/rpc/rpc_pb_service"
-import { Config, miners } from "../types"
+import { Config, minersTypes } from "../types"
 import { promise } from "../util"
 
 /**
@@ -16,8 +16,8 @@ export const createMiners = (config: Config) => {
      */
     get: () =>
       promise(
-        (cb) => client.get(new miners.GetRequest(), cb),
-        (resp: miners.GetResponse) => resp.toObject(),
+        (cb) => client.get(new minersTypes.GetRequest(), cb),
+        (resp: minersTypes.GetResponse) => resp.toObject(),
       ),
   }
 }

--- a/src/net/index.ts
+++ b/src/net/index.ts
@@ -1,5 +1,5 @@
 import { RPCServiceClient } from "@textile/grpc-powergate-client/dist/net/rpc/rpc_pb_service"
-import { Config, net } from "../types"
+import { Config, netTypes } from "../types"
 import { promise } from "../util"
 
 /**
@@ -16,8 +16,8 @@ export const createNet = (config: Config) => {
      */
     listenAddr: () =>
       promise(
-        (cb) => client.listenAddr(new net.ListenAddrRequest(), cb),
-        (res: net.ListenAddrResponse) => res.toObject(),
+        (cb) => client.listenAddr(new netTypes.ListenAddrRequest(), cb),
+        (res: netTypes.ListenAddrResponse) => res.toObject(),
       ),
 
     /**
@@ -26,8 +26,8 @@ export const createNet = (config: Config) => {
      */
     peers: () =>
       promise(
-        (cb) => client.peers(new net.PeersRequest(), cb),
-        (res: net.PeersResponse) => res.toObject(),
+        (cb) => client.peers(new netTypes.PeersRequest(), cb),
+        (res: netTypes.PeersResponse) => res.toObject(),
       ),
 
     /**
@@ -36,11 +36,11 @@ export const createNet = (config: Config) => {
      * @returns The peer info
      */
     findPeer: (peerId: string) => {
-      const req = new net.FindPeerRequest()
+      const req = new netTypes.FindPeerRequest()
       req.setPeerId(peerId)
       return promise(
         (cb) => client.findPeer(req, cb),
-        (res: net.FindPeerResponse) => res.toObject(),
+        (res: netTypes.FindPeerResponse) => res.toObject(),
       )
     },
 
@@ -48,11 +48,11 @@ export const createNet = (config: Config) => {
      * Connect to a peer
      * @param peerInfo The peer info specifying the peer to connect to
      */
-    connectPeer: (peerInfo: net.PeerAddrInfo.AsObject) => {
-      const info = new net.PeerAddrInfo()
+    connectPeer: (peerInfo: netTypes.PeerAddrInfo.AsObject) => {
+      const info = new netTypes.PeerAddrInfo()
       info.setId(peerInfo.id)
       info.setAddrsList(peerInfo.addrsList)
-      const req = new net.ConnectPeerRequest()
+      const req = new netTypes.ConnectPeerRequest()
       req.setPeerInfo(info)
       return promise(
         (cb) => client.connectPeer(req, cb),
@@ -68,11 +68,11 @@ export const createNet = (config: Config) => {
      * @returns Information about the connectedness to the peer
      */
     connectedness: (peerId: string) => {
-      const req = new net.ConnectednessRequest()
+      const req = new netTypes.ConnectednessRequest()
       req.setPeerId(peerId)
       return promise(
         (cb) => client.connectedness(req, cb),
-        (res: net.ConnectednessResponse) => res.toObject(),
+        (res: netTypes.ConnectednessResponse) => res.toObject(),
       )
     },
 
@@ -81,7 +81,7 @@ export const createNet = (config: Config) => {
      * @param peerId The peer id to disconnect from
      */
     disconnectPeer: (peerId: string) => {
-      const req = new net.DisconnectPeerRequest()
+      const req = new netTypes.DisconnectPeerRequest()
       req.setPeerId(peerId)
       return promise(
         (cb) => client.disconnectPeer(req, cb),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,8 @@
 import { grpc } from "@improbable-eng/grpc-web"
-import * as ffs from "@textile/grpc-powergate-client/dist/ffs/rpc/rpc_pb"
-import * as health from "@textile/grpc-powergate-client/dist/health/rpc/rpc_pb"
-import * as miners from "@textile/grpc-powergate-client/dist/index/miner/rpc/rpc_pb"
-import * as net from "@textile/grpc-powergate-client/dist/net/rpc/rpc_pb"
+import * as ffsTypes from "@textile/grpc-powergate-client/dist/ffs/rpc/rpc_pb"
+import * as healthTypes from "@textile/grpc-powergate-client/dist/health/rpc/rpc_pb"
+import * as minersTypes from "@textile/grpc-powergate-client/dist/index/miner/rpc/rpc_pb"
+import * as netTypes from "@textile/grpc-powergate-client/dist/net/rpc/rpc_pb"
 
 /**
  * Object that allows you to configure the Powergate client
@@ -12,4 +12,4 @@ export interface Config extends grpc.RpcOptions {
   authToken?: string
 }
 
-export { ffs, health, miners, net }
+export { ffsTypes, healthTypes, minersTypes, netTypes }


### PR DESCRIPTION
Types used in apis can now be accessed like:

```
import { ffsTypes } from "@textile/powergate-client"
```
for example.
